### PR TITLE
Adds support for book cover images

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,7 @@
                  [metosin/ring-http-response "0.9.3"]
                  [mount "0.1.16"]
                  [nrepl "1.0.0"]
+                 [org.clj-commons/byte-streams "0.3.2"]
                  [org.clojure/clojure "1.11.1"]
                  [org.clojure/clojurescript "1.11.60" :scope "provided"]
                  [org.clojure/core.async "1.5.648"]

--- a/resources/migrations/20230502164252-adds-cover-images.down.sql
+++ b/resources/migrations/20230502164252-adds-cover-images.down.sql
@@ -1,0 +1,3 @@
+alter table catalog.book
+  drop column cover_image_data,
+  drop column cover_image_type;

--- a/resources/migrations/20230502164252-adds-cover-images.up.sql
+++ b/resources/migrations/20230502164252-adds-cover-images.up.sql
@@ -1,0 +1,3 @@
+alter table catalog.book
+  add column cover_image_data bytea default null,
+  add column cover_image_type text default null;

--- a/resources/sql/catalog.sql
+++ b/resources/sql/catalog.sql
@@ -1,5 +1,6 @@
 -- :name insert-book! :! :1
-insert into catalog.book (title, isbn) values (:title, :isbn)
+insert into catalog.book (title, isbn, cover_image_data, cover_image_type)
+values (:title, :isbn, :cover.data, :cover.type)
 returning *;
 
 -- :name delete-book! :! :n
@@ -14,6 +15,12 @@ where lower(title) like :title;
 select isbn, true as "available"
 from catalog.book
 where isbn = :isbn
+
+-- :name get-book-cover :? :1
+select isbn, cover_image_data, cover_image_type
+from catalog.book
+where isbn = :isbn
+  and cover_image_type = :type;
 
 -- :name get-books :? :*
 select isbn, true as "available"

--- a/src/clj/sugbi/catalog/db.clj
+++ b/src/clj/sugbi/catalog/db.clj
@@ -1,5 +1,6 @@
 (ns sugbi.catalog.db
  (:require
+  [byte-streams :as byte-streams]
   [camel-snake-kebab.core :as csk]
   [clojure.string :as str]
   [conman.core :as conman]
@@ -7,6 +8,13 @@
   [medley.core :as medley]))
 
 (conman/bind-connection db/*db* "sql/catalog.sql")
+
+
+(defn format-file
+  [temp-file]
+  (-> temp-file
+      :tempfile
+      byte-streams/to-byte-array))
 
 
 (defn matching-books

--- a/src/clj/sugbi/catalog/handlers.clj
+++ b/src/clj/sugbi/catalog/handlers.clj
@@ -1,5 +1,6 @@
 (ns sugbi.catalog.handlers
   (:require
+   [byte-streams :as byte-streams]
    [ring.util.http-response :as response]
    [sugbi.catalog.db :as catalog.db]
    [sugbi.catalog.core :as catalog.core]))
@@ -17,15 +18,30 @@
       catalog.core/available-fields))))
 
 
+(defn- image-type
+  [temp-file]
+  (let [image-type (->> temp-file
+                        :filename
+                        (re-find #".*\.(jpg|png)")
+                        second)]
+    image-type))
+
 (defn insert-book!
   [request]
-  (let [{:keys [_isbn _title]
-         :as book-info} (get-in request [:parameters :body])
-        is-librarian?   (get-in request [:session :is-librarian?])]
-    (if is-librarian?
-      (response/ok
-       (select-keys (catalog.db/insert-book! book-info) [:isbn :title]))
-      (response/forbidden {:message "Operation restricted to librarians"}))))
+  (let [{:keys [isbn title file]
+         :as _book-info} (get-in request [:parameters :multipart])
+        is-librarian?    (get-in request [:session :is-librarian?])]
+    (def the-file file)
+    (cond
+      (not is-librarian?)      (response/forbidden {:message "Operation restricted to librarians"})
+      (nil? (image-type file)) (response/unsupported-media-type {:message "Server just admits JPG or PNG files"})
+      :else                    (response/ok
+                                (select-keys
+                                 (catalog.db/insert-book! {:isbn  isbn
+                                                           :title title
+                                                           :cover {:data (catalog.db/format-file file)
+                                                                   :type (image-type file)}})
+                                 [:isbn :title])))))
 
 
 (defn delete-book!
@@ -45,4 +61,25 @@
                         isbn
                         catalog.core/available-fields)]
       (response/ok book-info)
+      (response/not-found {:isbn isbn}))))
+
+
+(defn- image-content-type
+  [type]
+  (case type
+    "jpg" "image/jpeg"
+    "png" "image/png"))
+
+(defn get-book-cover
+  [request]
+  (let [isbn       (get-in request [:parameters :path :isbn])
+        media-type (get-in request [:parameters :path :ext])]
+    (if-let [{image-data :cover_image_data
+              image-type :cover_image_type} (catalog.db/get-book-cover {:isbn isbn
+                                                                        :type media-type})]
+      (-> image-data
+          byte-streams/to-input-stream
+          response/ok
+          (response/header "Content-Type" (image-content-type image-type))
+          (response/header "Content-Length" (count image-data)))
       (response/not-found {:isbn isbn}))))


### PR DESCRIPTION
It has been requested that the system allow storing images of some book covers. These images may be in JPG or SVG format, and must be stored in the database.

The database model is adjusted to add a couple of columns where the image data will be stored as well as its file extension. In addition, the 'end point' for book registration is adjusted so that from now, a cover image must be provided. Finally, a new route is added to be able to consult the image of the book if it exists.

The `byte-streams` library was added to be able to serialize the information to the necessary formats in each system layer without directly using Java objects.